### PR TITLE
Drop the syslog.target requirement based on http://www.freedesktop.org/w...

### DIFF
--- a/rpm/wpa_supplicant.service
+++ b/rpm/wpa_supplicant.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=WPA Supplicant daemon
 Before=network.target
-After=syslog.target
+Requires=dbus.socket
+After=dbus.socket
 
 [Service]
 Type=dbus


### PR DESCRIPTION
...iki/Software/systemd/syslog/

[systemd] Drop syslog.target and add dbus.socket requirement.

Signed-off-by: Marko Saukko marko.saukko@jolla.com
