### PR TITLE
dbus: Reorder deauthentication and cleanup calls when removing a network...

### DIFF
--- a/rpm/wpa_supplicant-remove-interface-call-order.patch
+++ b/rpm/wpa_supplicant-remove-interface-call-order.patch
@@ -1,0 +1,37 @@
+diff -Naur hostap.orig/wpa_supplicant/dbus/dbus_new_handlers.c hostap/wpa_supplicant/dbus/dbus_new_handlers.c
+--- hostap.orig/wpa_supplicant/dbus/dbus_new_handlers.c	2014-05-12 13:27:01.351691716 +0300
++++ hostap/wpa_supplicant/dbus/dbus_new_handlers.c	2014-05-12 13:27:51.319689907 +0300
+@@ -1533,16 +1533,6 @@
+ 
+ 	wpas_notify_network_removed(wpa_s, ssid);
+ 
+-	if (wpa_config_remove_network(wpa_s->conf, id) < 0) {
+-		wpa_printf(MSG_ERROR,
+-			   "wpas_dbus_handler_remove_network[dbus]: "
+-			   "error occurred when removing network %d", id);
+-		reply = wpas_dbus_error_unknown_error(
+-			message, "error removing the specified network on "
+-			"this interface.");
+-		goto out;
+-	}
+-
+ 	if (ssid == wpa_s->current_ssid)
+ 		wpa_supplicant_deauthenticate(wpa_s,
+ 					      WLAN_REASON_DEAUTH_LEAVING);
+@@ -1553,6 +1543,16 @@
+ 		wpa_supplicant_req_scan(wpa_s, 0, 0);
+ 	}
+ 
++	if (wpa_config_remove_network(wpa_s->conf, id) < 0) {
++		wpa_printf(MSG_ERROR,
++			   "wpas_dbus_handler_remove_network[dbus]: "
++			   "error occurred when removing network %d", id);
++		reply = wpas_dbus_error_unknown_error(
++			message, "error removing the specified network on "
++			"this interface.");
++		goto out;
++	}
++
+ 
+ out:
+ 	os_free(iface);

--- a/rpm/wpa_supplicant.spec
+++ b/rpm/wpa_supplicant.spec
@@ -20,6 +20,7 @@ Patch3:     wpa_supplicant-quiet-scan-results-message.patch
 Patch4:     wpa_supplicant-openssl-more-algs.patch
 Patch5:     wpa_supplicant-gui-qt4.patch
 Patch6:     libnl3-includes.patch
+Patch7:     wpa_supplicant-remove-interface-call-order.patch
 BuildRequires:  pkgconfig(libnl-3.0)
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(openssl)
@@ -73,6 +74,8 @@ unless you know what you're doing.
 %patch5 -p1
 # libnl3-includes.patch
 %patch6 -p1
+# wpa_supplicant-remove-interface-call-order.patch
+%patch7 -p1
 
 %build
 pushd wpa_supplicant


### PR DESCRIPTION
....

Valgrind indicates reference to already freed memory if function
wpa_config_remove_network() is called prior to calling
wpa_supplicant_deauthenticate(), and this can lead to a crash.
Inverting the call order fixes the problem.

[wpa_supplicant] Reorder calls when removing a network.

Signed-off-by: Hannu Mallat hannu.mallat@jollamobile.com
