### PR TITLE
Do not retry scan after failure if operating in ap_mode. MER#1208

### DIFF
--- a/hostap/wpa_supplicant/scan.c
+++ b/hostap/wpa_supplicant/scan.c
@@ -186,6 +186,9 @@ static void wpas_trigger_scan_cb(struct wpa_radio_work *work, int deinit)
 		if (wpa_s->disconnected)
 			retry = 0;
 
+		if (wpa_s->last_ssid && wpa_s->last_ssid->mode == WPAS_MODE_AP)
+			retry = 0;
+
 		wpa_supplicant_notify_scanning(wpa_s, 0);
 		wpas_notify_scan_done(wpa_s, 0);
 		if (wpa_s->wpa_state == WPA_SCANNING)


### PR DESCRIPTION
Commit 2d9c99e37b29a639dafa431df38e1586a31ba887 introduced
a regression while running in ap_mode together with ap_scan
configured with value of 2.

Retrying caused following path to be called:
wpa_supplicant_req_scan()->wpa_supplicant_scan()->
wpa_supplicant_assoc_try()->wpa_supplicant_associate()->
wpa_supplicant_create_ap()

Which eventually teared down the currently configured
ap_mode by calling wpa_supplicant_ap_deinit().

Signed-off-by: Pasi Sjöholm <pasi.sjoholm@jollamobile.com>