### PR TITLE
[wpa_supplicant] Fix ap_mode teardown with upstream patches. MER#1208

### DIFF
--- a/hostap/wpa_supplicant/dbus/dbus_new_handlers.c
+++ b/hostap/wpa_supplicant/dbus/dbus_new_handlers.c
@@ -1336,6 +1336,7 @@ DBusMessage * wpas_dbus_handler_scan(DBusMessage *message,
 			}
 
 			if (params.freqs && params.freqs[0]) {
+				wpa_s->last_scan_req = MANUAL_SCAN_REQ;
 				if (wpa_supplicant_trigger_scan(wpa_s,
 								&params)) {
 					reply = wpas_dbus_error_scan_error(
@@ -1362,6 +1363,7 @@ DBusMessage * wpas_dbus_handler_scan(DBusMessage *message,
 			wpa_supplicant_cancel_sched_scan(wpa_s);
 		}
 
+		wpa_s->last_scan_req = MANUAL_SCAN_REQ;
 		if (wpa_supplicant_trigger_scan(wpa_s, &params)) {
 			reply = wpas_dbus_error_scan_error(
 				message, "Scan request rejected");

--- a/hostap/wpa_supplicant/dbus/dbus_new_handlers.c
+++ b/hostap/wpa_supplicant/dbus/dbus_new_handlers.c
@@ -1327,14 +1327,25 @@ DBusMessage * wpas_dbus_handler_scan(DBusMessage *message,
 				message,
 				"You can specify only Channels in passive scan");
 			goto out;
-		} else if (params.freqs && params.freqs[0]) {
-			if (wpa_supplicant_trigger_scan(wpa_s, &params)) {
-				reply = wpas_dbus_error_scan_error(
-					message, "Scan request rejected");
-			}
 		} else {
-			wpa_s->scan_req = MANUAL_SCAN_REQ;
-			wpa_supplicant_req_scan(wpa_s, 0, 0);
+			if (wpa_s->sched_scanning) {
+				wpa_printf(MSG_DEBUG,
+					   "%s[dbus]: Stop ongoing sched_scan to allow requested scan to proceed",
+					   __func__);
+				wpa_supplicant_cancel_sched_scan(wpa_s);
+			}
+
+			if (params.freqs && params.freqs[0]) {
+				if (wpa_supplicant_trigger_scan(wpa_s,
+								&params)) {
+					reply = wpas_dbus_error_scan_error(
+						message,
+						"Scan request rejected");
+				}
+			} else {
+				wpa_s->scan_req = MANUAL_SCAN_REQ;
+				wpa_supplicant_req_scan(wpa_s, 0, 0);
+			}
 		}
 	} else if (os_strcmp(type, "active") == 0) {
 		if (!params.num_ssids) {
@@ -1344,6 +1355,13 @@ DBusMessage * wpas_dbus_handler_scan(DBusMessage *message,
 #ifdef CONFIG_AUTOSCAN
 		autoscan_deinit(wpa_s);
 #endif /* CONFIG_AUTOSCAN */
+		if (wpa_s->sched_scanning) {
+			wpa_printf(MSG_DEBUG,
+				   "%s[dbus]: Stop ongoing sched_scan to allow requested scan to proceed",
+				   __func__);
+			wpa_supplicant_cancel_sched_scan(wpa_s);
+		}
+
 		if (wpa_supplicant_trigger_scan(wpa_s, &params)) {
 			reply = wpas_dbus_error_scan_error(
 				message, "Scan request rejected");

--- a/hostap/wpa_supplicant/scan.c
+++ b/hostap/wpa_supplicant/scan.c
@@ -776,6 +776,9 @@ static void wpa_supplicant_scan(void *eloop_ctx, void *timeout_ctx)
 	}
 
 	if (wpa_s->last_scan_req != MANUAL_SCAN_REQ &&
+#ifdef CONFIG_AP
+	    !wpa_s->ap_iface &&
+#endif /* CONFIG_AP */
 	    wpa_s->conf->ap_scan == 2) {
 		wpa_s->connect_without_scan = NULL;
 		wpa_s->prev_scan_wildcard = 0;

--- a/hostap/wpa_supplicant/scan.c
+++ b/hostap/wpa_supplicant/scan.c
@@ -186,9 +186,6 @@ static void wpas_trigger_scan_cb(struct wpa_radio_work *work, int deinit)
 		if (wpa_s->disconnected)
 			retry = 0;
 
-		if (wpa_s->last_ssid && wpa_s->last_ssid->mode == WPAS_MODE_AP)
-			retry = 0;
-
 		wpa_supplicant_notify_scanning(wpa_s, 0);
 		wpas_notify_scan_done(wpa_s, 0);
 		if (wpa_s->wpa_state == WPA_SCANNING)


### PR DESCRIPTION
Includes also "dbus: Stop ongoing scheduled scan when scan is requested" to avoid code conflict now and in the future.