### PR TITLE
[systemd] Cosmetic fixes for wpa_supplicant service files. Fixes JB#31722

### DIFF
--- a/hostap/wpa_supplicant/dbus/fi.epitest.hostap.WPASupplicant.service.in
+++ b/hostap/wpa_supplicant/dbus/fi.epitest.hostap.WPASupplicant.service.in
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=fi.epitest.hostap.WPASupplicant
-Exec=@BINDIR@/wpa_supplicant -B -u -f /var/log/wpa_supplicant.log -c /etc/wpa_supplicant/wpa_supplicant.conf -P /var/run/wpa_supplicant.pid
+Exec=/bin/false
 User=root
-SystemdService=wpa_supplicant.service
+SystemdService=dbus-fi.epitest.hostap.WPASupplicant.service

--- a/hostap/wpa_supplicant/dbus/fi.w1.wpa_supplicant1.service.in
+++ b/hostap/wpa_supplicant/dbus/fi.w1.wpa_supplicant1.service.in
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=fi.w1.wpa_supplicant1
-Exec=@BINDIR@/wpa_supplicant -B -u -f /var/log/wpa_supplicant.log -c /etc/wpa_supplicant/wpa_supplicant.conf -P /var/run/wpa_supplicant.pid
+Exec=/bin/false
 User=root
-SystemdService=wpa_supplicant.service
+SystemdService=dbus-fi.w1.wpa_supplicant1.service

--- a/rpm/wpa_supplicant.service
+++ b/rpm/wpa_supplicant.service
@@ -7,10 +7,12 @@ After=dbus.socket
 [Service]
 Type=dbus
 BusName=fi.w1.wpa_supplicant1
+BusName=fi.epitest.hostap.WPASupplicant
 EnvironmentFile=-/etc/sysconfig/wpa_supplicant
 ExecStart=/usr/sbin/wpa_supplicant -u -c /etc/wpa_supplicant/wpa_supplicant.conf -O/var/run/wpa_supplicant $INTERFACES $DRIVERS $OTHER_ARGS
 Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
-
+Alias=dbus-fi.epitest.hostap.WPASupplicant.service
+Alias=dbus-fi.w1.wpa_supplicant1.service

--- a/rpm/wpa_supplicant.spec
+++ b/rpm/wpa_supplicant.spec
@@ -48,6 +48,8 @@ rm -rf %{buildroot}
 
 # init scripts
 install -D -m 0755 %{SOURCE3} %{buildroot}/%{_lib}/systemd/system/%{name}.service
+ln -s %{name}.service %{buildroot}/%{_lib}/systemd/system/dbus-fi.epitest.hostap.WPASupplicant.service
+ln -s %{name}.service %{buildroot}/%{_lib}/systemd/system/dbus-fi.w1.wpa_supplicant1.service
 install -D -m 0644 %{SOURCE4} %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
 
 # config
@@ -97,6 +99,8 @@ rm /var/log/wpa_supplicant.log || :
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 /%{_lib}/systemd/system/%{name}.service
+/%{_lib}/systemd/system/dbus-fi.epitest.hostap.WPASupplicant.service
+/%{_lib}/systemd/system/dbus-fi.w1.wpa_supplicant1.service
 %{_sysconfdir}/dbus-1/system.d/%{name}.conf
 %{_datadir}/dbus-1/system-services/fi.epitest.hostap.WPASupplicant.service
 %{_datadir}/dbus-1/system-services/fi.w1.wpa_supplicant1.service


### PR DESCRIPTION
Set Exec=/bin/false for fi.epitest.hostap.WPASupplicant and
fi.w1.wpa_supplicant1.service D-Bus services because of systemd activation.
Add bus name and aliases to systemd service file.

Signed-off-by: Igor Zhbanov <igor.zhbanov@jolla.com>